### PR TITLE
[wip] Docker disk metrics

### DIFF
--- a/bin/ecs-info.js
+++ b/bin/ecs-info.js
@@ -25,7 +25,7 @@ var cli = meow(`
 
 var command = cli.input[0];
 var name = cli.input[1];
-var region = cli.region || 'us-east-1';
+var region = cli.flags.region || 'us-east-1';
 
 if (!command) console.error('ERROR: no command specified');
 if (!name) console.error('ERROR: no cluster name specified');

--- a/cli/instances.js
+++ b/cli/instances.js
@@ -1,0 +1,5 @@
+module.exports = instances;
+
+function instances(cluster) {
+  cluster.instances.forEach(instance => console.log(`${instance.ec2InstanceId}: ${instance.dockerDiskUtilization}`));
+}

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk');
 const Service = require('./Service');
 const Instance = require('./Instance');
 const Task = require('./Task');
+const d3 = require('d3-queue');
 
 function traceable(err, noPromise) {
   Error.captureStackTrace(err, arguments.callee);
@@ -111,11 +112,13 @@ function describeCluster(cluster, region) {
   const ec2 = new AWS.EC2(options);
   const elb = new AWS.ELB(options);
   const elbv2 = new AWS.ELBv2(options);
+  const cw = new AWS.CloudWatch(options);
 
   return Promise.all([
     ecs.describeClusters({ clusters: [cluster] }).promise().catch(traceable),
     describeTasks(ecs, params),
-    describeInstances(ecs, ec2, params),
+    describeInstances(ecs, ec2, params)
+      .then(instances => describeDockerStorage(cw, instances, cluster)),
     describeServices(ecs, params)
       .then(serviceData => describeLoadBalancerTargets(elb, elbv2, serviceData)),
   ])
@@ -262,6 +265,54 @@ function describeLoadBalancerTargets(elb, elbv2, servicesData) {
   }, []);
 
   return Promise.all(promises).then(() => servicesData);
+}
+
+function describeDockerStorage(cw, instances, cluster) {
+  const queue = d3.queue(10);
+  const region = cluster.split(':')[3];
+  const now = Date.now();
+  const name = cluster.split(':').pop()
+    .replace(/^cluster\//, '')
+    .replace(/-Cluster-.*$/, '');
+
+  instances
+    .forEach(instance => {
+      // console.log({
+      //   Namespace: 'System/Linux',
+      //   MetricName: 'dockerDiskUtilization',
+      //   Dimensions: [
+      //     { Name: 'InstanceId', Value: `${instance.ec2InstanceId}-${name}-${region}` }
+      //   ],
+      //   Statistics: ['Maximum'],
+      //   StartTime: (new Date(now - 5 * 60 * 1000)).toISOString(),
+      //   EndTime: (new Date(now)).toISOString(),
+      //   Period: 5 * 60
+      // });
+      queue.defer(next => cw.getMetricStatistics({
+        Namespace: 'System/Linux',
+        MetricName: 'dockerDiskUtilization',
+        Dimensions: [
+          { Name: 'InstanceId', Value: `${instance.ec2InstanceId}-${name}-${region}` }
+        ],
+        Statistics: ['Maximum'],
+        StartTime: (new Date(now - 5 * 60 * 1000)).toISOString(),
+        EndTime: (new Date(now)).toISOString(),
+        Period: 5 * 60
+      }, next));
+    });
+
+  return new Promise((resolve, reject) => {
+    queue.awaitAll((err, results) => {
+      if (err) return reject(err);
+      resolve(results);
+    });
+  })
+  .then(results => {
+    results.forEach((metric, i) => {
+      if (metric.Datapoints[0]) instances[i].dockerDiskUtilization = `${metric.Datapoints[0].Maximum}%`;
+    });
+    return instances;
+  });
 }
 
 function byName(name, region) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "agentkeepalive": "^2.2.0",
     "aws-sdk": "^2.5.5",
     "cloudfriend": "^1.1.0",
+    "d3-queue": "^3.0.3",
     "easy-table": "^1.0.0",
     "inquirer": "^1.2.2",
     "meow": "^3.7.0"


### PR DESCRIPTION
Adds a CloudWatch fetch for the docker disk utilization metric that is collected by https://github.com/mapbox/cwput.

CLI command works (right now) like this:

```
》ecs-info instances processing-staging
i-1234: 1.68%
i-5678: 3.93%
i-9012: 0.15%
i-3456: 2.8%
```

... just reporting the % of the docker disk that is full.
